### PR TITLE
stable qujax 0.1.1

### DIFF
--- a/pytket/extensions/qujax/qujax_convert.py
+++ b/pytket/extensions/qujax/qujax_convert.py
@@ -18,7 +18,7 @@ Methods to allow conversion between qujax and pytket
 
 from typing import Tuple, Sequence, Optional
 from jax import numpy as jnp
-from qujax.circuit import CallableOptionalArrayArg, get_params_to_statetensor_func  # type: ignore
+from qujax import UnionCallableOptionalArray, get_params_to_statetensor_func  # type: ignore
 from pytket import Qubit, Circuit  # type: ignore
 
 
@@ -35,7 +35,7 @@ def _tk_qubits_to_inds(tk_qubits: Sequence[Qubit]) -> Tuple[int, ...]:
     return tuple(q.index[0] for q in tk_qubits)
 
 
-def tk_to_qujax(circuit: Circuit) -> CallableOptionalArrayArg:
+def tk_to_qujax(circuit: Circuit) -> UnionCallableOptionalArray:
     """
     Converts a tket circuit into a function that maps circuit parameters
     to a statetensor. Assumes all circuit gates can be found in qujax.gates.
@@ -69,7 +69,7 @@ def tk_to_qujax(circuit: Circuit) -> CallableOptionalArrayArg:
 
 def tk_to_qujax_symbolic(
     circuit: Circuit, symbol_map: Optional[dict] = None
-) -> CallableOptionalArrayArg:
+) -> UnionCallableOptionalArray:
     """
     Converts a tket circuit with symbolics parameters and a symbolic parameter map
     into a function that maps circuit parameters to a statetensor.

--- a/tests/test_tket.py
+++ b/tests/test_tket.py
@@ -26,13 +26,17 @@ def _test_circuit(circuit: Circuit, param: Union[None, jnp.ndarray]):
     true_sv = circuit.get_statevector()
 
     apply_circuit = tk_to_qujax(circuit)
+    jit_apply_circuit = jit(apply_circuit)
 
-    test_st = apply_circuit(param)
+    if param is None:
+        test_st = apply_circuit()
+        test_jit_sv = jit_apply_circuit().flatten()
+    else:
+        test_st = apply_circuit(param)
+        test_jit_sv = jit_apply_circuit(param).flatten()
+
     test_sv = test_st.flatten()
     assert jnp.all(jnp.abs(test_sv - true_sv) < 1e-5)
-
-    jit_apply_circuit = jit(apply_circuit)
-    test_jit_sv = jit_apply_circuit(param).flatten()
     assert jnp.all(jnp.abs(test_jit_sv - true_sv) < 1e-5)
 
     if param is not None:
@@ -207,8 +211,8 @@ def test_HH():
 
     apply_circuit = tk_to_qujax(circuit)
 
-    st1 = apply_circuit(None)
-    st2 = apply_circuit(None, st1)
+    st1 = apply_circuit()
+    st2 = apply_circuit(st1)
 
     all_zeros_sv = jnp.array(jnp.arange(st2.size) == 0, dtype=int)
 

--- a/tests/test_tket_symbolic.py
+++ b/tests/test_tket_symbolic.py
@@ -31,12 +31,16 @@ def _test_circuit(circuit: Circuit, symbols: Sequence[Symbol]):
     true_sv = circuit_inst.get_statevector()
 
     apply_circuit = tk_to_qujax_symbolic(circuit, symbol_map)
-
-    test_sv = apply_circuit(params).flatten()
-    assert jnp.all(jnp.abs(test_sv - true_sv) < 1e-5)
-
     jit_apply_circuit = jit(apply_circuit)
-    test_jit_sv = jit_apply_circuit(params).flatten()
+
+    if params.size == 0:
+        test_sv = apply_circuit().flatten()
+        test_jit_sv = jit_apply_circuit().flatten()
+    else:
+        test_sv = apply_circuit(params).flatten()
+        test_jit_sv = jit_apply_circuit(params).flatten()
+
+    assert jnp.all(jnp.abs(test_sv - true_sv) < 1e-5)
     assert jnp.all(jnp.abs(test_jit_sv - true_sv) < 1e-5)
 
     if len(params):
@@ -172,8 +176,8 @@ def test_HH():
 
     apply_circuit = tk_to_qujax_symbolic(circuit)
 
-    st1 = apply_circuit(None)
-    st2 = apply_circuit(None, st1)
+    st1 = apply_circuit()
+    st2 = apply_circuit(st1)
     all_zeros_sv = jnp.array(jnp.arange(st2.size) == 0, dtype=int)
     assert jnp.all(jnp.abs(st2.flatten() - all_zeros_sv) < 1e-5)
 


### PR DESCRIPTION
Update for qujax 0.1.1

Now no parameter input to `qujax.get_params_to_statetensor_func` when no parameters are given, type hints updated to match. 