### PR TITLE
remove custom type hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist
 obj
 docs/extensions
 .ipynb_checkpoints
+.idea

--- a/pytket/extensions/qujax/qujax_convert.py
+++ b/pytket/extensions/qujax/qujax_convert.py
@@ -16,9 +16,9 @@
 Methods to allow conversion between qujax and pytket
 """
 
-from typing import Tuple, Sequence, Optional
+from typing import Tuple, Sequence, Optional, Union, Callable
 from jax import numpy as jnp
-from qujax import UnionCallableOptionalArray, get_params_to_statetensor_func  # type: ignore
+from qujax import get_params_to_statetensor_func  # type: ignore
 from pytket import Qubit, Circuit  # type: ignore
 
 
@@ -35,7 +35,12 @@ def _tk_qubits_to_inds(tk_qubits: Sequence[Qubit]) -> Tuple[int, ...]:
     return tuple(q.index[0] for q in tk_qubits)
 
 
-def tk_to_qujax(circuit: Circuit) -> UnionCallableOptionalArray:
+def tk_to_qujax(
+    circuit: Circuit,
+) -> Union[
+    Callable[[jnp.ndarray, Optional[jnp.ndarray]], jnp.ndarray],
+    Callable[[Optional[jnp.ndarray]], jnp.ndarray],
+]:
     """
     Converts a tket circuit into a function that maps circuit parameters
     to a statetensor. Assumes all circuit gates can be found in qujax.gates.
@@ -71,7 +76,10 @@ def tk_to_qujax(circuit: Circuit) -> UnionCallableOptionalArray:
 
 def tk_to_qujax_symbolic(
     circuit: Circuit, symbol_map: Optional[dict] = None
-) -> UnionCallableOptionalArray:
+) -> Union[
+    Callable[[jnp.ndarray, Optional[jnp.ndarray]], jnp.ndarray],
+    Callable[[Optional[jnp.ndarray]], jnp.ndarray],
+]:
     """
     Converts a tket circuit with symbolics parameters and a symbolic parameter map
     into a function that maps circuit parameters to a statetensor.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket ~= 1.5",
-        "qujax ~= 0.1.5",
+        "qujax ~= 0.1.7",
     ],
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
Removed a custom type hint loaded from qujax

Although qujax has undergone some minor updates since last pytket-qujax release, shouldn't break the code but might have some awkward mypy stuff etc to fix