### PR TITLE
Release/0.5.0

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.4.0"
+__extension_version__ = "0.5.0"
 __extension_name__ = "pytket-qujax"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 ~~~~~~~~~
 
-0.5.0 (unreleased )
--------------------
+0.5.0 (September 2022)
+----------------------
 
 * Consolidate `tk_to_qujax_args` with `tk_to_qujax_args_symbolic`,
   `tk_to_qujax` with `tk_to_qujax_symbolic`,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 ~~~~~~~~~
 
+0.5.0 (unreleased )
+-------------------
+
+* Consolidate `tk_to_qujax_args` with `tk_to_qujax_args_symbolic`,
+  `tk_to_qujax` with `tk_to_qujax_symbolic`,
+  `print_circuit` with `print_circuit_symbolic`
+  and removed all the symbolic versions.
+  Now, all the functions have a default symbol_map argument
+  which tells wherther or not to make it symbolic.
+* Renamed `qujax_to_tk` to `qujax_args_to_tk`
+
 0.4.0 (August 2022)
 -------------------
 

--- a/pytket/extensions/qujax/__init__.py
+++ b/pytket/extensions/qujax/__init__.py
@@ -19,11 +19,8 @@
 from ._metadata import __extension_version__, __extension_name__  # type: ignore
 from .qujax_convert import (
     tk_to_qujax,
-    tk_to_qujax_symbolic,
     tk_to_qujax_args,
-    tk_to_qujax_args_symbolic,
     print_circuit,
-    print_circuit_symbolic,
-    qujax_to_tk,
+    qujax_args_to_tk,
     _tk_qubits_to_inds,
 )

--- a/pytket/extensions/qujax/_metadata.py
+++ b/pytket/extensions/qujax/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.2.0"
+__extension_version__ = "0.5.0"
 __extension_name__ = "pytket-qujax"

--- a/tests/test_tket.py
+++ b/tests/test_tket.py
@@ -19,7 +19,7 @@ import qujax  # type: ignore
 from pytket.circuit import Circuit, Qubit  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore
 from pytket.utils import QubitPauliOperator  # type: ignore
-from pytket.extensions.qujax import tk_to_qujax, tk_to_qujax_args, qujax_to_tk
+from pytket.extensions.qujax import tk_to_qujax, tk_to_qujax_args, qujax_args_to_tk
 
 
 def _test_circuit(
@@ -53,7 +53,7 @@ def _test_circuit(
         circuit_commands = [
             com for com in circuit.get_commands() if str(com.op) != "Barrier"
         ]
-        circuit_2 = qujax_to_tk(*tk_to_qujax_args(circuit))
+        circuit_2 = qujax_args_to_tk(*tk_to_qujax_args(circuit))
         assert all(
             g.op.type == g2.op.type
             for g, g2 in zip(circuit_commands, circuit_2.get_commands())

--- a/tests/test_tket_symbolic.py
+++ b/tests/test_tket_symbolic.py
@@ -19,9 +19,9 @@ from jax import numpy as jnp, jit, grad, random
 
 from pytket.circuit import Circuit
 from pytket.extensions.qujax import (
-    tk_to_qujax_symbolic,
-    tk_to_qujax_args_symbolic,
-    qujax_to_tk,
+    tk_to_qujax,
+    tk_to_qujax_args,
+    qujax_args_to_tk,
 )
 
 
@@ -36,7 +36,7 @@ def _test_circuit(
     circuit_inst.symbol_substitution(param_map)
     true_sv = circuit_inst.get_statevector()
 
-    apply_circuit = tk_to_qujax_symbolic(circuit, symbol_map)
+    apply_circuit = tk_to_qujax(circuit, symbol_map)
     jit_apply_circuit = jit(apply_circuit)
 
     if not len(params):
@@ -62,7 +62,7 @@ def _test_circuit(
         circuit_commands = [
             com for com in circuit.get_commands() if str(com.op) != "Barrier"
         ]
-        circuit_2 = qujax_to_tk(*tk_to_qujax_args_symbolic(circuit, symbol_map))
+        circuit_2 = qujax_args_to_tk(*tk_to_qujax_args(circuit, symbol_map))
         assert all(
             g.op.type == g2.op.type
             for g, g2 in zip(circuit_commands, circuit_2.get_commands())
@@ -194,7 +194,7 @@ def test_HH() -> None:
     circuit = Circuit(3)
     circuit.H(0)
 
-    apply_circuit = tk_to_qujax_symbolic(circuit)
+    apply_circuit = tk_to_qujax(circuit)
 
     st1 = apply_circuit()
     st2 = apply_circuit(st1)


### PR DESCRIPTION
0.5.0 (September 2022)
----------------------

* Consolidate `tk_to_qujax_args` with `tk_to_qujax_args_symbolic`,
  `tk_to_qujax` with `tk_to_qujax_symbolic`,
  `print_circuit` with `print_circuit_symbolic`
  and removed all the symbolic versions.
  Now, all the functions have a default symbol_map argument
  which tells wherther or not to make it symbolic.
* Renamed `qujax_to_tk` to `qujax_args_to_tk`