### PR TITLE
Release/0.6.0

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.5.0"
+__extension_version__ = "0.6.0"
 __extension_name__ = "pytket-qujax"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 ~~~~~~~~~
 
+0.6.0 (September 2022)
+-------------------
+
+* Added support for a blend of numerical and symbolic
+  parameterised gates.
+* Added automatic conversion of non-parameterised gates
+  not found in qujax.gates (in symbolic implementation only)
+* Raises error if measurements found
+
 0.5.0 (September 2022)
 ----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 * Added automatic conversion of non-parameterised gates
   not found in qujax.gates (in symbolic implementation only)
 * Raises error if measurements found
+* Updated pytket version requirement to 1.6.
 
 0.5.0 (September 2022)
 ----------------------

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.5",
+        "pytket ~= 1.6",
         "qujax ~= 0.2.5",
     ],
     classifiers=[

--- a/tests/test_tket.py
+++ b/tests/test_tket.py
@@ -15,6 +15,7 @@
 from typing import Union, Any
 from jax import numpy as jnp, jit, grad, random  # type: ignore
 import qujax  # type: ignore
+import pytest
 
 from pytket.circuit import Circuit, Qubit  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore
@@ -232,6 +233,15 @@ def test_HH() -> None:
     all_zeros_sv = jnp.array(jnp.arange(st2.size) == 0, dtype=int)  # type: ignore
 
     assert jnp.all(jnp.abs(st2.flatten() - all_zeros_sv) < 1e-5)
+
+
+def test_measure_error() -> None:
+    circuit = Circuit(3, 3)
+    circuit.H(0)
+    circuit.Measure(0, 0)
+
+    with pytest.raises(TypeError):
+        _ = tk_to_qujax(circuit)
 
 
 def test_quantum_hamiltonian() -> None:

--- a/tests/test_tket_symbolic.py
+++ b/tests/test_tket_symbolic.py
@@ -126,6 +126,28 @@ def test_CZ_qrev() -> None:
     _test_circuit(circuit, symbols, True)
 
 
+def test_symbolic_numeric_blend() -> None:
+    symbols = [Symbol("p0")]  # type: ignore
+
+    circuit = Circuit(2)
+    circuit.H(0)
+    circuit.Rz(symbols[0], 1)
+    circuit.Rx(0.1, 1)
+    circuit.Rz(0.2, 1)
+
+    _test_circuit(circuit, symbols)
+
+
+def test_not_in_qujaxgates() -> None:
+    symbols = [Symbol("p0")]  # type: ignore
+
+    circuit = Circuit(2)
+    circuit.Rx(symbols[0], 0)
+    circuit.ZZPhase(0.1, 0, 1)
+
+    _test_circuit(circuit, symbols)
+
+
 def test_CX_Barrier_Rx() -> None:
     symbols = [Symbol("p0"), Symbol("p1")]  # type: ignore
 
@@ -136,6 +158,18 @@ def test_CX_Barrier_Rx() -> None:
     circuit.Rx(symbols[1], 2)
 
     _test_circuit(circuit, symbols)
+
+
+def test_measure_error() -> None:
+    symbols = [Symbol("p0")]  # type: ignore
+    symbol_map = dict(zip(symbols, range(len(symbols))))
+
+    circuit = Circuit(3, 3)
+    circuit.Rx(symbols[0], 0)
+    circuit.Measure(0, 0)
+
+    with pytest.raises(TypeError):
+        _ = tk_to_qujax(circuit, symbol_map)
 
 
 def test_circuit1() -> None:


### PR DESCRIPTION
0.6.0 (September 2022)
-------------------

* Added support for a blend of numerical and symbolic
  parameterised gates.
* Added automatic conversion of non-parameterised gates
  not found in qujax.gates (in symbolic implementation only)
* Raises error if measurements found
* Updated pytket version requirement to 1.6.