### PR TITLE
Add `lambdify_gates` optional parameter to `tk_to_qujax_args`, `_symbolic_command_to_gate_and_param_inds`, `tk_to_qujax`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ~~~~~~~~~
 
+0.21.0 (TBD)
+-------------------
+
+* Add `lambdify_gates` optional parameter to `tk_to_qujax`, `tk_to_qujax_args`, 
+   `_symbolic_command_to_gate_and_param_inds`. 
+
 0.20.0 (July 2024)
 ------------------
 

--- a/pytket/extensions/qujax/qujax_convert.py
+++ b/pytket/extensions/qujax/qujax_convert.py
@@ -72,9 +72,10 @@ def _symbolic_command_to_gate_and_param_inds(
     :param symbol_map: ``dict``, maps symbolic pytket parameters following the order
         in this dict.
     :type symbol_map: dict
-    :param lambdify_gates: boolean that determines whether gate is represented by a string or by a function
-        returned by sympy's `lambdify`. In the latter case, symbol math is captured
-        (i.e. algebraic manipulations of the parameter symbols are reflected in the returned function).
+    :param lambdify_gates: boolean that determines whether gate is represented by a
+        string or by a function returned by sympy's `lambdify`. In the latter case,
+        symbol math is captured (i.e. algebraic manipulations of the parameter symbols
+        are reflected in the returned function).
     :type lambdify_gates: bool
     :return: tuple of gate and parameter indices
         gate will be given as either a string in qujax.gates (if command is not
@@ -145,9 +146,10 @@ def tk_to_qujax_args(
         If ``None``, parameterised gates determined by ``qujax.gates``. \n
         If ``dict``, maps symbolic pytket parameters following the order in this dict.
     :type symbol_map: Optional[dict]
-    :param lambdify_gates: boolean that determines whether gates are represented by a string or by a function
-        returned by sympy's `lambdify`. In the latter case, symbol math is captured
-        (i.e. algebraic manipulations of the parameter symbols are reflected in the returned function).
+    :param lambdify_gates: boolean that determines whether gates are represented by a
+        string or by a function returned by sympy's `lambdify`. In the latter case,
+        symbol math is captured (i.e. algebraic manipulations of the parameter symbols
+        are reflected in the returned function).
     :type lambdify_gates: bool
     :return: Tuple of arguments defining a (parameterised) quantum circuit
         that can be sent to ``qujax.get_params_to_statetensor_func``. The elements of
@@ -243,9 +245,10 @@ def tk_to_qujax(
     :param simulator: string in ('statetensor', 'densitytensor', 'unitarytensor')
         corresponding to qujax simulator type. Defaults to statetensor.
     :type simulator: str
-    :param lambdify_gates: boolean that determines whether gates are captured as a string or as a function
-        returned by sympy's `lambdify`. In the latter case, symbol math is taken into account
-        (i.e. algebraic manipulations of the parameter symbols are reflected in the returned function).
+    :param lambdify_gates: boolean that determines whether gates are captured as a
+        string or as a function returned by sympy's `lambdify`. In the latter case,
+        symbol math is taken into account (i.e. algebraic manipulations of the parameter
+        symbols are reflected in the returned function).
     :type lambdify_gates: bool
     :return: Function which maps parameters (and optional statetensor_in)
         to a statetensor.

--- a/pytket/extensions/qujax/qujax_convert.py
+++ b/pytket/extensions/qujax/qujax_convert.py
@@ -216,7 +216,7 @@ def tk_to_qujax(
     symbol_map: Optional[dict] = None,
     simulator: str = "statetensor",
     lambdify_gates: bool = False,
-) -> qujax.typing.PureCircuitFunction:
+) -> qujax.UnionCallableOptionalArray:
     """
     Converts a pytket circuit into a function that maps circuit parameters
     to a statetensor (or densitytensor). Assumes all circuit gates can be found in

--- a/tests/test_tket_symbolic.py
+++ b/tests/test_tket_symbolic.py
@@ -26,7 +26,10 @@ from pytket.extensions.qujax import (
 
 
 def _test_circuit(
-    circuit: Circuit, symbols: Sequence[Symbol], test_two_way: bool = False
+    circuit: Circuit,
+    symbols: Sequence[Symbol],
+    test_two_way: bool = False,
+    lambdify_gates: bool = False,
 ) -> None:
     params = random.uniform(random.PRNGKey(0), (len(symbols),)) * 2
     param_map = dict(zip(symbols, params))
@@ -37,7 +40,7 @@ def _test_circuit(
     true_sv = circuit_inst.get_statevector()
     true_probs = jnp.square(jnp.abs(true_sv))
 
-    apply_circuit = tk_to_qujax(circuit, symbol_map)
+    apply_circuit = tk_to_qujax(circuit, symbol_map, lambdify_gates=lambdify_gates)
     jit_apply_circuit = jit(apply_circuit)
 
     apply_circuit_dt = tk_to_qujax(circuit, symbol_map, simulator="densitytensor")
@@ -132,6 +135,17 @@ def test_CZ() -> None:
     circuit.CZ(0, 1)
 
     _test_circuit(circuit, symbols, True)
+
+
+def test_symbol_manipulaton() -> None:
+    symbols = [Symbol("p0")]  # type: ignore
+
+    circuit = Circuit(2)
+    circuit.H(0)
+    circuit.Rz(1.2 * symbols[0], 0)
+    circuit.CZ(0, 1)
+
+    _test_circuit(circuit, symbols, True, True)
 
 
 def test_CZ_qrev() -> None:


### PR DESCRIPTION
# Description
Add `lambdify_gates` optional parameter to `tk_to_qujax_args`, `_symbolic_command_to_gate_and_param_inds` and `tk_to_qujax`.

When this is set to `True`, manipulations of the symbols representing the parameters are correctly captured in the corresponding qujax function (i.e. if one rescales or shifts a symbol `s` representing a parameter, e.g. `1.1*s - 2`, this is taken into account).

Note that when the gate functions are lambdified, the resulting qujax function will be slower if not compiled. Since the expected usage for these functions is for them to be compiled, I think is fine, as all the overhead is then eliminated. I will post the script that I used to benchmark this below.

# Related issues

Addresses issue #144. 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
