### PR TITLE
Detect whether parameters are symbols and lambdify accordingly

### DIFF
--- a/pytket/extensions/qujax/qujax_convert.py
+++ b/pytket/extensions/qujax/qujax_convert.py
@@ -87,7 +87,11 @@ def _symbolic_command_to_gate_and_param_inds(
             gate_params = command.op.params
             if len(free_symbols) == 0:
                 gate = qujax_gate(*gate_params)
-            elif len(free_symbols) == 1 and isinstance(free_symbols[0], Symbol):
+            elif (
+                len(free_symbols) == 1
+                and len(gate_params) == 1
+                and isinstance(gate_params[0], Symbol)
+            ):
                 gate = gate_str
             else:
                 gate_lambda = lambdify(free_symbols, gate_params)

--- a/tests/test_tket_symbolic.py
+++ b/tests/test_tket_symbolic.py
@@ -134,12 +134,42 @@ def test_CZ() -> None:
     _test_circuit(circuit, symbols, True)
 
 
-def test_symbol_manipulaton() -> None:
+def test_single_symbol_manipulaton() -> None:
     symbols = [Symbol("p0")]  # type: ignore
 
     circuit = Circuit(2)
     circuit.H(0)
     circuit.Rz(1.2 * symbols[0], 0)
+    circuit.CZ(0, 1)
+
+    _test_circuit(circuit, symbols, False)
+
+
+def test_single_symbol_manipulaton_multiple_appearances() -> None:
+    symbols = [Symbol("p0")]  # type: ignore
+
+    circuit = Circuit(2)
+    circuit.H(0)
+    circuit.Rz(1.2 * symbols[0], 0)
+    circuit.Rz(0.5 * symbols[0], 1)
+    circuit.Rx(symbols[0], 1)
+    circuit.CZ(0, 1)
+
+    _test_circuit(circuit, symbols, False)
+
+
+def test_multiple_symbol_manipulaton() -> None:
+    symbols = [Symbol("p0"), Symbol("p1"), Symbol("p2")]  # type: ignore
+
+    circuit = Circuit(2)
+    circuit.H(0)
+    circuit.Rz(1.2 * symbols[0], 0)
+    circuit.Rz(0.5 * symbols[1], 1)
+    circuit.XXPhase(symbols[0], 0, 1)
+    circuit.YYPhase(0.2 * symbols[0], 0, 1)
+    circuit.ZZPhase(0.3 * symbols[1], 0, 1)
+    circuit.YYPhase(symbols[1], 0, 1)
+    circuit.U3(0.1 * symbols[0], 0.7 * symbols[1], 0.8 * symbols[2], 1)
     circuit.CZ(0, 1)
 
     _test_circuit(circuit, symbols, False)

--- a/tests/test_tket_symbolic.py
+++ b/tests/test_tket_symbolic.py
@@ -134,6 +134,17 @@ def test_CZ() -> None:
     _test_circuit(circuit, symbols, True)
 
 
+def test_symbol_manipulaton() -> None:
+    symbols = [Symbol("p0")]  # type: ignore
+
+    circuit = Circuit(2)
+    circuit.H(0)
+    circuit.Rz(1.2 * symbols[0], 0)
+    circuit.CZ(0, 1)
+
+    _test_circuit(circuit, symbols, False)
+
+
 def test_CZ_qrev() -> None:
     symbols = [Symbol("p0")]
 


### PR DESCRIPTION
# Description

Adds additional conditions for a gate belonging to a pytket circuit to be represented by a string in the output of `tk_to_qujax_args`. Otherwise, the gate is capture by sympy's `lambdify`

This makes it so that manipulations of symbols representing the parameters are correctly captured in the corresponding qujax function (i.e. if one rescales or shifts a symbol `s` representing a parameter, e.g. `1.1*s - 2`, this is taken into account).

# Related issues

Addresses issue #144. Aims to replace #145.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.

