### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'
@@ -76,7 +76,7 @@ jobs:
       run: |
         cd docs
         bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+        poetry run pip install ../.
     - name: Build docs
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,5 +5,7 @@ API documentation
     :special-members:
     :members:
 
+.. automodule:: pytket.extensions.qujax._metadata
+
 .. automodule:: pytket.extensions.qujax.qujax_convert
     :members:

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -9,9 +9,6 @@ cp pytket-docs-theming/conf.py .
 # Get the name of the project
 EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 
-# Correct github link in navbar
-sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
-
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -66,7 +66,7 @@ Changelog
 ----------------------
 
 * Update qujax version requirement to 0.3.1
-* Add support for simulator=unitary in tk_to_qujax
+* Add support for ``simulator=unitary`` in :py:func:`~.tk_to_qujax`
 * Updated pytket version requirement to 1.10.
 
 0.10.0 (November 2022)
@@ -78,7 +78,7 @@ Changelog
 ---------------------
 
 * Update qujax version requirement to 0.3.0
-* Add simulator argument to `tk_to_qujax` to enable
+* Add simulator argument to :py:func:`~.tk_to_qujax` to enable
   conversion to densitytensor simulator
 
 0.8.0 (November 2022)
@@ -89,7 +89,7 @@ Changelog
 0.7.1 (October 2022)
 --------------------
 
-* Added `tk_to_param` function
+* Added :py:func:`~.tk_to_param` function
 
 0.7.0 (October 2022)
 --------------------
@@ -108,26 +108,26 @@ Changelog
 * Added support for a blend of numerical and symbolic
   parameterised gates.
 * Added automatic conversion of non-parameterised gates
-  not found in qujax.gates (in symbolic implementation only)
+  not found in ``qujax.gates`` (in symbolic implementation only)
 * Raises error if measurements found
 * Updated pytket version requirement to 1.6.
 
 0.5.0 (September 2022)
 ----------------------
 
-* Consolidate `tk_to_qujax_args` with `tk_to_qujax_args_symbolic`,
-  `tk_to_qujax` with `tk_to_qujax_symbolic`,
-  `print_circuit` with `print_circuit_symbolic`
+* Consolidate :py:func:`~.tk_to_qujax_args` with ``tk_to_qujax_args_symbolic``,
+  :py:func:`~.tk_to_qujax` with ``tk_to_qujax_symbolic``,
+  :py:func:`~.print_circuit` with ``print_circuit_symbolic``
   and removed all the symbolic versions.
   Now, all the functions have a default symbol_map argument
   which tells wherther or not to make it symbolic.
-* Renamed `qujax_to_tk` to `qujax_args_to_tk`
+* Renamed ``qujax_to_tk`` to :py:func:`~.qujax_args_to_tk`
 
 0.4.0 (August 2022)
 -------------------
 
-* Add tk_to_qujax_args, tk_to_qujax_args_symbolic
-* Add print_circuit, print_circuit_symbolic
+* Add :py:func:`~.tk_to_qujax_args`, ``tk_to_qujax_args_symbolic``
+* Add :py:func:`~.print_circuit`, ``print_circuit_symbolic``
 * Updated qujax version requirement to 0.2.5.
 
 0.3.0 (August 2022)
@@ -149,5 +149,5 @@ Changelog
 0.1.0 (July 2022)
 -----------------
 
-* add tk_to_qujax and tk_to_qujax_symbolic
-* update to qujax version 0.1.3
+* Add :py:func:`~.tk_to_qujax` and ``tk_to_qujax_symbolic``
+* Update to qujax version 0.1.3

--- a/pytket/extensions/qujax/__init__.py
+++ b/pytket/extensions/qujax/__init__.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Conversion from pytket to qujax circuits"""
-
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__
 from .qujax_convert import (

--- a/pytket/extensions/qujax/qujax_convert.py
+++ b/pytket/extensions/qujax/qujax_convert.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Methods to allow conversion between qujax and pytket
-"""
-
 from collections.abc import Callable, Sequence
 from functools import wraps
 from typing import Any
@@ -33,7 +29,7 @@ def _tk_qubits_to_inds(tk_qubits: Sequence[Qubit]) -> tuple[int, ...]:
     Convert Sequence of pytket qubits objects to tuple of integers qubit indices.
 
     :param tk_qubits: Sequence of pytket qubit object
-        (as stored in ``pytket.Circuit.qubits``).
+        (as stored in :py:attr:`pytket._tket.circuit.Circuit.qubits`).
     :return: Tuple of qubit indices.
     """
     return tuple(q.index[0] for q in tk_qubits)
@@ -64,11 +60,11 @@ def _symbolic_command_to_gate_and_param_inds(
     """
     Convert pytket command to qujax (gate, parameter indices) tuple.
 
-    :param command: pytket circuit command from .get_commands()
+    :param command: pytket circuit command from :py:meth:`~pytket._tket.circuit.Circuit.get_commands`
     :param symbol_map: ``dict``, maps symbolic pytket parameters following the order
         in this dict.
     :return: tuple of gate and parameter indices
-        gate will be given as either a string in qujax.gates (if command is not
+        gate will be given as either a string in ``qujax.gates`` (if command is not
         symbolic or has single symbolic argument with no operations) or a function
         that maps parameters to a jax unitary matrix.
     """
@@ -116,17 +112,17 @@ def tk_to_qujax_args(
     The ``symbol_map`` argument controls the interpretation of any symbolic parameters
     found in ``circuit.free_symbols()``.
 
-    - If ``symbol_map`` is ``None``, circuit.free_symbols() will be ignored.
+    - If ``symbol_map`` is ``None``, ``circuit.free_symbols()`` will be ignored.
       Parameterised gates will be determined based on whether they are stored as
       functions (parameterised) or arrays (non-parameterised) in qujax.gates. The order
-      of qujax circuit parameters is the same as in circuit.get_commands().
+      of qujax circuit parameters is the same as in ``circuit.get_commands()``.
     - If ``symbol_map`` is provided as a ``dict``, assign qujax circuit parameters to
       symbolic parameters in ``circuit.free_symbols()``; the order of qujax circuit
       parameters will be given by this dict. Keys of the dict should be symbolic pytket
       parameters as in ``circuit.free_symbols()`` and the values indicate
       the index of the qujax circuit parameter -- integer indices starting from 0.
 
-    The conversion can also be checked with ``print_circuit``.
+    The conversion can also be checked with :py:func:`print_circuit`.
 
     :param circuit: Circuit to be converted (without any measurement commands).
     :param symbol_map:
@@ -197,18 +193,18 @@ def tk_to_qujax(
     ``qujax.gates``. The ``symbol_map`` argument controls the interpretation of any
     symbolic parameters found in ``circuit.free_symbols()``.
 
-    - If ``symbol_map`` is ``None``, circuit.free_symbols() will be ignored.
+    - If ``symbol_map`` is ``None``, ``circuit.free_symbols()`` will be ignored.
       Parameterised gates will be determined based on whether they are stored as
       functions (parameterised) or arrays (non-parameterised) in qujax.gates. The order
-      of qujax circuit parameters is the same as in circuit.get_commands().
+      of qujax circuit parameters is the same as in ``circuit.get_commands()``.
     - If ``symbol_map`` is provided as a ``dict``, assign qujax circuit parameters to
       symbolic parameters in ``circuit.free_symbols()``; the order of qujax circuit
       parameters will be given by this dict. Keys of the dict should be symbolic pytket
       parameters as in ``circuit.free_symbols()`` and the values indicate
       the index of the qujax circuit parameter -- integer indices starting from 0.
 
-    The conversion can be checked by examining the output from ``tk_to_qujax_args``
-    or ``print_circuit``.
+    The conversion can be checked by examining the output from :py:func:`tk_to_qujax_args`
+    or :py:func:`print_circuit`.
 
     :param circuit: Circuit to be converted (without any measurement commands).
     :param symbol_map:
@@ -279,7 +275,7 @@ def print_circuit(  # noqa: PLR0913
     Returns and prints basic string representation of circuit.
 
     For more information on the ``symbol_map`` parameter refer to the
-    ``tk_to_qujax`` or ``tk_to_qujax_args`` documentation.
+    :py:func:`tk_to_qujax` or :py:func:`tk_to_qujax_args` documentation.
 
     :param circuit: Circuit to be converted (without any measurement commands).
     :param symbol_map:
@@ -309,7 +305,7 @@ def qujax_args_to_tk(
     Convert qujax args into pytket Circuit.
 
     :param gate_seq: Sequence of gates. Each element is a string matching an array
-        or function in qujax.gates
+        or function in ``qujax.gates``
     :param qubit_inds_seq: Sequences of qubits (ints) that gates are acting on.
     :param param_inds_seq: Sequence of parameter indices that gates are using,
         i.e. [[0], [], [5, 2]] tells qujax that the first gate uses the first parameter,

--- a/pytket/extensions/qujax/qujax_convert.py
+++ b/pytket/extensions/qujax/qujax_convert.py
@@ -34,9 +34,7 @@ def _tk_qubits_to_inds(tk_qubits: Sequence[Qubit]) -> tuple[int, ...]:
 
     :param tk_qubits: Sequence of pytket qubit object
         (as stored in ``pytket.Circuit.qubits``).
-    :type tk_qubits: Sequence[Qubit]
     :return: Tuple of qubit indices.
-    :rtype: Tuple[int]
     """
     return tuple(q.index[0] for q in tk_qubits)
 
@@ -49,11 +47,8 @@ def _append_func(f: Callable, func_to_append: Callable) -> Callable:
     with the same signature as f.
 
     :param f: Base function, whose signature is retained.
-    :type f: Callable
     :param func_to_append: Function to apply to the output of
-    :type func_to_append: Callable
     :return: Decorated function that executes func_to_append(f(*args **kwargs))
-    :rtype: Callable
     """
 
     @wraps(f)
@@ -70,15 +65,12 @@ def _symbolic_command_to_gate_and_param_inds(
     Convert pytket command to qujax (gate, parameter indices) tuple.
 
     :param command: pytket circuit command from .get_commands()
-    :type command: Command
     :param symbol_map: ``dict``, maps symbolic pytket parameters following the order
         in this dict.
-    :type symbol_map: dict
     :return: tuple of gate and parameter indices
         gate will be given as either a string in qujax.gates (if command is not
         symbolic or has single symbolic argument with no operations) or a function
         that maps parameters to a jax unitary matrix.
-    :rtype: Tuple[Union[str, Callable[[jnp.ndarray], jnp.ndarray]], Sequence[int]]
     """
     gate_str = command.op.type.name
     free_symbols = list(command.op.free_symbols())
@@ -137,11 +129,9 @@ def tk_to_qujax_args(
     The conversion can also be checked with ``print_circuit``.
 
     :param circuit: Circuit to be converted (without any measurement commands).
-    :type circuit: pytket.Circuit
     :param symbol_map:
         If ``None``, parameterised gates determined by ``qujax.gates``. \n
         If ``dict``, maps symbolic pytket parameters following the order in this dict.
-    :type symbol_map: Optional[dict]
     :return: Tuple of arguments defining a (parameterised) quantum circuit
         that can be sent to ``qujax.get_params_to_statetensor_func``. The elements of
         the tuple (qujax args) are as follows
@@ -150,8 +140,6 @@ def tk_to_qujax_args(
         - Sequence of sequences describing which qubits gates act on.
         - Sequence of sequences of parameter indices that gates are using.
         - Number of qubits.
-
-    :rtype: Tuple[Sequence[str], Sequence[Sequence[int]], Sequence[Sequence[int]], int]
     """
     if symbol_map:
         assert set(symbol_map.keys()) == circuit.free_symbols(), (
@@ -223,21 +211,15 @@ def tk_to_qujax(
     or ``print_circuit``.
 
     :param circuit: Circuit to be converted (without any measurement commands).
-    :type circuit: pytket.Circuit
     :param symbol_map:
         If ``None``, parameterised gates determined by ``qujax.gates``. \n
         If ``dict``, maps symbolic pytket parameters following the order in this dict.
-    :type symbol_map: Optional[dict]
     :param simulator: string in ('statetensor', 'densitytensor', 'unitarytensor')
         corresponding to qujax simulator type. Defaults to statetensor.
-    :type simulator: str
     :return: Function which maps parameters (and optional statetensor_in)
         to a statetensor.
         If the circuit has no parameters, the resulting function
         will only take the optional ``statetensor_in`` as an argument.
-    :rtype: Callable[[jnp.ndarray, jnp.ndarray = None], jnp.ndarray]
-        or Callable[[jnp.ndarray = None], jnp.ndarray]
-        if no parameters found in circuit
     """
     qujax_args = tk_to_qujax_args(circuit, symbol_map)
     simulator = simulator.lower()
@@ -262,9 +244,7 @@ def tk_to_param(circuit: Circuit) -> jnp.ndarray:
 
     :param circuit: Circuit to be converted
         (without any measurement commands or symbolic gates).
-    :type circuit: pytket.Circuit
     :return: 1D array containing values of parameters
-    :rtype: jnp.ndarray
     """
 
     if circuit.is_symbolic():
@@ -302,23 +282,15 @@ def print_circuit(  # noqa: PLR0913
     ``tk_to_qujax`` or ``tk_to_qujax_args`` documentation.
 
     :param circuit: Circuit to be converted (without any measurement commands).
-    :type circuit: pytket.Circuit
     :param symbol_map:
         If ``None``, parameterised gates determined by ``qujax.gates``. \n
         If ``dict``, maps symbolic pytket parameters following the order in this dict.
-    :type symbol_map: Optional[dict]
     :param qubit_min: Index of first qubit to display.
-    :type qubit_min: int
     :param qubit_max: Index of final qubit to display.
-    :type qubit_max: int
     :param gate_ind_min: Index of gate to start circuit printing.
-    :type gate_ind_min: int
     :param gate_ind_max: Index of gate to stop circuit printing.
-    :type gate_ind_max: int
     :param sep_length: Number of dashes to separate gates.
-    :type sep_length: int
     :return: String representation of circuit
-    :rtype: List[str]
     """
     g, q, p, nq = tk_to_qujax_args(circuit, symbol_map)
     return qujax.print_circuit(  # type: ignore
@@ -338,20 +310,14 @@ def qujax_args_to_tk(
 
     :param gate_seq: Sequence of gates. Each element is a string matching an array
         or function in qujax.gates
-    :type gate_seq: Sequence[str]
     :param qubit_inds_seq: Sequences of qubits (ints) that gates are acting on.
-    :type qubit_inds_seq: Sequence[Sequence[int]]
     :param param_inds_seq: Sequence of parameter indices that gates are using,
         i.e. [[0], [], [5, 2]] tells qujax that the first gate uses the first parameter,
         the second gate is not parameterised and the third gates used the fifth and
         second parameters.
-    :type param_inds_seq: Sequence[Sequence[int]]
     :param n_qubits: Number of qubits, if fixed.
-    :type n_qubits: int
     :param param: Circuit parameters, if parameterised. Defaults to all zeroes.
-    :type param: jnp.ndarray
     :return: Circuit
-    :rtype: pytket.Circuit
     """
     if any(not isinstance(gate_name, str) for gate_name in gate_seq):
         raise TypeError(

--- a/tests/test_tket.py
+++ b/tests/test_tket.py
@@ -14,11 +14,11 @@
 
 from typing import Any
 
+import numpy as np
 import pytest
 import qujax  # type: ignore
 from jax import grad, jit, random
 from jax import numpy as jnp
-import numpy as np
 
 from pytket.circuit import Circuit, Qubit
 from pytket.extensions.qujax import (

--- a/tests/test_tket.py
+++ b/tests/test_tket.py
@@ -298,7 +298,7 @@ def test_quantum_hamiltonian() -> None:
     state = random.uniform(random.PRNGKey(0), shape=(2**n_qubits,))
     state /= jnp.linalg.norm(state)
 
-    tket_exp = tket_op.state_expectation(np.asarray(state))  # type: ignore
+    tket_exp = tket_op.state_expectation(np.asarray(state))
     jax_exp = st_to_exp(state.reshape((2,) * n_qubits))
 
     assert jnp.abs(tket_exp - jax_exp) < 1e-5

--- a/tests/test_tket.py
+++ b/tests/test_tket.py
@@ -18,6 +18,7 @@ import pytest
 import qujax  # type: ignore
 from jax import grad, jit, random
 from jax import numpy as jnp
+import numpy as np
 
 from pytket.circuit import Circuit, Qubit
 from pytket.extensions.qujax import (
@@ -297,7 +298,7 @@ def test_quantum_hamiltonian() -> None:
     state = random.uniform(random.PRNGKey(0), shape=(2**n_qubits,))
     state /= jnp.linalg.norm(state)
 
-    tket_exp = tket_op.state_expectation(state)  # type: ignore
+    tket_exp = tket_op.state_expectation(np.asarray(state))  # type: ignore
     jax_exp = st_to_exp(state.reshape((2,) * n_qubits))
 
     assert jnp.abs(tket_exp - jax_exp) < 1e-5


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards CQCL/tket#1857, following on from CQCL/tket#1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
